### PR TITLE
Bullseye555 pm issue 623

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # TBA
 * Fix PiBuilder @marshy #604
+* Update SQLite search logic to search for strings instead of whole words only
 
 # 0.3.13 - 2023-09-04
 * Add Config option to fix FA icon's no longer loading. @marshyonline

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -592,7 +592,7 @@ router.route('/messageSearch')
           qb.leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id');
         }
         if (dbtype == 'sqlite3' && query != '') {
-          //This wraps the query with the wildcard symbol so SQLite searches for the string, regardless of any spaces
+          //This wraps the query with the wildcard symbol so SQLite searches for strings, rather than whole words
           query = '%' + query + '%'
           qb.whereRaw('messages_search_index.message LIKE ?', query)
           qb.orWhereRaw('messages_search_index.alias LIKE ?', query)

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -592,7 +592,11 @@ router.route('/messageSearch')
           qb.leftJoin('capcodes', 'capcodes.id', '=', 'messages.alias_id');
         }
         if (dbtype == 'sqlite3' && query != '') {
-          qb.whereRaw('messages_search_index MATCH ?', query)
+          //This wraps the query with the wildcard symbol so SQLite searches for the string, regardless of any spaces
+          query = '%' + query + '%'
+          qb.whereRaw('messages_search_index.message LIKE ?', query)
+          qb.orWhereRaw('messages_search_index.alias LIKE ?', query)
+          qb.orWhereRaw('messages_search_index.agency LIKE ?', query)
         } else if (dbtype == 'mysql' && query != '') {
           //This wraps the search query in quotes so MySQL searches for the complete term rather than individual words.
           query = '"' + query + '"'


### PR DESCRIPTION

# Description

Update from MATCH (whole word results only) to LIKE (string results, regardless of where the string is in the decode) for SQLite3 Message Search string

Fixes [https://github.com/pagermon/pagermon/issues/623](https://github.com/pagermon/pagermon/issues/623)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tested searching whole-words
- [X] Tested searching for partial words
- [X] Tested searching for numbers
- [X] Tested searching for strings containing symbols (eg: **@,#/*!$^&()-+.**)

##NOTE: SQL wildcard symbols **_** and **%** continue to function as wildcard symbols

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated changelog.md with changes made



